### PR TITLE
Version/rc

### DIFF
--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -1,0 +1,19 @@
+---
+dependencies:
+  - role: git
+galaxy_info:
+  author: Michael Kaiser
+  role_name: git
+  description: Setup of git to work in the cli on the servers
+  license: license (MIT)
+  min_ansible_version: "2.10"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - git
+    - deployment

--- a/roles/git/tasks/git-install.yml
+++ b/roles/git/tasks/git-install.yml
@@ -1,0 +1,7 @@
+---
+- name: Install git from apt
+  ansible.builtin.apt:
+    name:
+      - git
+    update_cache: true
+    state: latest # noqa package-latest

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Install git
+  ansible.builtin.include_tasks: git-install.yml
+  tags:
+    - role::git

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+mongodb_container_name: emplabs-mongodb
+mongodb_image: mongo
+mongodb_image_version: latest
+mongodb_volume_name: emplabs_mongodb_volume
+mongodb_network: mongodb
+mongodb_port: 27017

--- a/roles/mongodb/meta/main.yml
+++ b/roles/mongodb/meta/main.yml
@@ -1,0 +1,19 @@
+---
+dependencies:
+  - role: docker
+galaxy_info:
+  author: Michael Kaiser
+  role_name: mongodb
+  description: Setup of mongodb in docker container
+  license: license (MIT)
+  min_ansible_version: "2.10"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - mongodb
+    - deployment

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Setup mongodb docker
+  ansible.builtin.include_tasks: mongodb-setup.yml
+  tags:
+    - role::mongodb

--- a/roles/mongodb/tasks/mongodb-setup.yml
+++ b/roles/mongodb/tasks/mongodb-setup.yml
@@ -1,0 +1,22 @@
+---
+- name: Create mongodb network
+  community.docker.docker_network:
+    name: "{{ mongodb_network }}"
+
+- name: Create mongodb volume
+  community.docker.docker_volume:
+    name: "{{ mongodb_volume_name }}"
+
+- name: Setup Mongodb in a docker container
+  community.docker.docker_container:
+    name: "{{ mongodb_container_name }}"
+    image: "{{ mongodb_image }}:{{ mongodb_image_version }}"
+    recreate: true
+    pull: true
+    networks:
+      - name: "{{ mongodb_network }}"
+    ports:
+      - "{{ mongodb_port }}:27017"
+    restart_policy: unless-stopped
+    volumes:
+      - "{{ mongodb_volume_name }}/data:/data/db"

--- a/roles/zabbix_agent2/defaults/main.yml
+++ b/roles/zabbix_agent2/defaults/main.yml
@@ -22,3 +22,5 @@ zabbix_agent2_include: /etc/zabbix/zabbix_agent2.d/*.conf
 zabbix_agent2_pidFile: /var/run/zabbix/zabbix_agent2.pid
 zabbix_agent2_pluginSocket: /run/zabbix/agent.plugin.sock
 zabbix_agent2_controlSocket: /run/zabbix/agent.sock
+
+zabbix_description: Managed with ansible

--- a/roles/zabbix_agent2/tasks/zabbix-registration.yml
+++ b/roles/zabbix_agent2/tasks/zabbix-registration.yml
@@ -25,4 +25,5 @@
         port: "{{ zabbix_agent_port }}"
     tags: "{{ zabbix_tags | default([]) }}"
     macros: "{{ zabbix_macros | default([]) }}"
+    description: "Managed by ansible {{  zabbix_description }}"
   delegate_to: localhost


### PR DESCRIPTION
This pull request introduces two new Ansible roles (`git` and `mongodb`) and makes minor updates to the `zabbix_agent2` role. The most important changes include defining metadata and tasks for the new roles, configuring MongoDB to run in a Docker container, and adding a description field for Zabbix agent registration.

### New Ansible Roles

#### Git Role:
* Added metadata (`roles/git/meta/main.yml`) to define the role's purpose, dependencies, supported platforms, and tags.
* Created a task file (`roles/git/tasks/git-install.yml`) to install Git using the `apt` module.
* Included the Git installation task in the main task file (`roles/git/tasks/main.yml`).

#### MongoDB Role:
* Added metadata (`roles/mongodb/meta/main.yml`) to define the role's purpose, dependencies, supported platforms, and tags.
* Defined default variables for MongoDB configuration, such as container name, image, and port (`roles/mongodb/defaults/main.yml`).
* Created tasks to set up MongoDB in a Docker container, including network and volume creation (`roles/mongodb/tasks/mongodb-setup.yml`) and included these tasks in the main task file (`roles/mongodb/tasks/main.yml`). [[1]](diffhunk://#diff-80ec1bb99605611279554d535663265042fe59b2bdb72c565a5f6ea4a2122abcR1-R22) [[2]](diffhunk://#diff-f2bf1c8ab2d4c875bc6760bdd568125e1840e825b306dd248fec217a08f7f54bR1-R5)

### Updates to Zabbix Agent Role
* Added a default variable `zabbix_description` to provide a description for Zabbix agent configurations (`roles/zabbix_agent2/defaults/main.yml`).
* Updated Zabbix agent registration to include the description field (`roles/zabbix_agent2/tasks/zabbix-registration.yml`).